### PR TITLE
last point execution mode

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/CMakeLists.txt
+++ b/moveit_planners/pilz_industrial_motion_planner/CMakeLists.txt
@@ -218,22 +218,32 @@ if(CATKIN_ENABLE_TESTING)
   )
 
   # Planning Integration tests
-  add_rostest_gmock(integrationtest_sequence_action_capability
-    test/integrationtest_sequence_action_capability.test
-    test/integrationtest_sequence_action_capability.cpp
+  add_rostest_gmock(integrationtest_sequence_action_preemption
+    test/integrationtest_sequence_action_preemption.test
+    test/integrationtest_sequence_action_preemption.cpp
   )
-  target_link_libraries(integrationtest_sequence_action_capability
+  target_link_libraries(integrationtest_sequence_action_preemption
+    ${catkin_LIBRARIES}
+    ${pilz_testutils_LIBRARIES}
+    ${${PROJECT_NAME}_INTEGRATIONTEST_LIBRARIES}
+  )
+
+  add_rostest_gmock(integrationtest_sequence_action
+    test/integrationtest_sequence_action.test
+    test/integrationtest_sequence_action.cpp
+  )
+  target_link_libraries(integrationtest_sequence_action
     ${catkin_LIBRARIES}
     ${pilz_testutils_LIBRARIES}
     ${${PROJECT_NAME}_INTEGRATIONTEST_LIBRARIES}
   )
 
   add_rostest(test/integrationtest_sequence_action_capability_with_gripper.test
-    DEPENDENCIES integrationtest_sequence_action_capability
+    DEPENDENCIES integrationtest_sequence_action
   )
 
   add_rostest(test/integrationtest_sequence_action_capability_frankaemika_panda.test
-    DEPENDENCIES integrationtest_sequence_action_capability
+    DEPENDENCIES integrationtest_sequence_action
   )
 
   add_rostest_gtest(integrationtest_sequence_service_capability

--- a/moveit_planners/pilz_industrial_motion_planner/package.xml
+++ b/moveit_planners/pilz_industrial_motion_planner/package.xml
@@ -43,8 +43,8 @@
   <test_depend>pilz_testutils</test_depend>
   <test_depend>pilz_industrial_motion_planner_testutils</test_depend>
   <test_depend>moveit_resources_prbt_moveit_config</test_depend>
-  <test_depend>prbt_support</test_depend>
-  <test_depend>prbt_pg70_support</test_depend>
+  <test_depend>moveit_resources_prbt_support</test_depend>
+  <test_depend>moveit_resources_prbt_pg70_support</test_depend>
   <test_depend>code_coverage</test_depend>
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/moveit_planners/pilz_industrial_motion_planner/test/integrationtest_sequence_action.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/integrationtest_sequence_action.cpp
@@ -61,7 +61,6 @@
 #include "moveit_msgs/MoveGroupSequenceAction.h"
 
 static constexpr int WAIT_FOR_RESULT_TIME_OUT{ 5 };          // seconds
-static constexpr int TIME_BEFORE_CANCEL_GOAL{ 2 };           // seconds
 static constexpr int WAIT_FOR_ACTION_SERVER_TIME_OUT{ 10 };  // seconds
 
 const std::string SEQUENCE_ACTION_NAME("/sequence_move_group");
@@ -393,36 +392,6 @@ TEST_F(IntegrationTestSequenceAction, TestActionServerCallbacks)
 
   // wait for the ecpected events
   BARRIER({ GOAL_SUCCEEDED_EVENT, SERVER_IDLE_EVENT });
-}
-
-/**
- * @brief Tests that goal can be cancelled.
- *
- * Test Sequence:
- *    1. Send goal for planning and execution.
- *    2. Cancel goal before it finishes.
- *
- * Expected Results:
- *    1. Goal is sent to the action server.
- *    2. Goal is cancelled. Execution stops.
- */
-TEST_F(IntegrationTestSequenceAction, TestCancellingOfGoal)
-{
-  Sequence seq{ data_loader_->getSequence("ComplexSequence") };
-
-  moveit_msgs::MoveGroupSequenceGoal seq_goal;
-  seq_goal.request = seq.toRequest();
-
-  ac_.sendGoal(seq_goal);
-  // wait for 2 seconds
-  ros::Duration(TIME_BEFORE_CANCEL_GOAL).sleep();
-
-  ac_.cancelGoal();
-  ac_.waitForResult(ros::Duration(WAIT_FOR_RESULT_TIME_OUT));
-
-  moveit_msgs::MoveGroupSequenceResultConstPtr res = ac_.getResult();
-  EXPECT_EQ(res->response.error_code.val, moveit_msgs::MoveItErrorCodes::PREEMPTED)
-      << "Error code should be preempted.";
 }
 
 /**

--- a/moveit_planners/pilz_industrial_motion_planner/test/integrationtest_sequence_action.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/integrationtest_sequence_action.cpp
@@ -130,7 +130,7 @@ void IntegrationTestSequenceAction::SetUp()
   move_group_->setJointValueTarget(robot_state);
   move_group_->move();
 
-  ASSERT_TRUE(isAtExpectedPosition(robot_state, *(move_group_->getCurrentState()), joint_position_tolerance_));
+  ASSERT_TRUE(isAtExpectedPosition(robot_state, *(move_group_->getCurrentState()), joint_position_tolerance_, group_name_));
 }
 
 /**
@@ -421,7 +421,7 @@ TEST_F(IntegrationTestSequenceAction, TestPlanOnlyFlag)
   EXPECT_FALSE(res->response.planned_trajectories.empty()) << "Planned trajectory is empty";
 
   ASSERT_TRUE(
-      isAtExpectedPosition(*(move_group_->getCurrentState()), start_config.toRobotState(), joint_position_tolerance_))
+      isAtExpectedPosition(*(move_group_->getCurrentState()), start_config.toRobotState(), joint_position_tolerance_, group_name_))
       << "Robot did move although \"PlanOnly\" flag set.";
 }
 
@@ -456,7 +456,7 @@ TEST_F(IntegrationTestSequenceAction, TestIgnoreRobotStateForPlanOnly)
   EXPECT_FALSE(res->response.planned_trajectories.empty()) << "Planned trajectory is empty";
 
   ASSERT_TRUE(
-      isAtExpectedPosition(*(move_group_->getCurrentState()), start_config.toRobotState(), joint_position_tolerance_))
+      isAtExpectedPosition(*(move_group_->getCurrentState()), start_config.toRobotState(), joint_position_tolerance_, group_name_))
       << "Robot did move although \"PlanOnly\" flag set.";
 }
 

--- a/moveit_planners/pilz_industrial_motion_planner/test/integrationtest_sequence_action.test
+++ b/moveit_planners/pilz_industrial_motion_planner/test/integrationtest_sequence_action.test
@@ -33,31 +33,27 @@ POSSIBILITY OF SUCH DAMAGE.
 -->
 
 <launch>
-
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
     <param name="/use_gui" value="false"/>
     <rosparam param="/source_list">[/move_group/fake_controller_joint_states]</rosparam>
   </node>
 
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true"
-        output="screen" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
 
   <arg name="debug" default="false"/>
-  <include file="$(find pilz_industrial_motion_planner)/test/test_robots/frankaemika_panda/launch/move_group.launch">
+  <include file="$(find moveit_resources_prbt_moveit_config)/launch/move_group.launch">
     <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
+    <arg name="pipeline" value="pilz_industrial_motion_planner" />
+    <arg name="execution_type" value="last point" />
   </include>
 
   <!-- run test -->
-  <test pkg="pilz_industrial_motion_planner" test-name="integrationtest_sequence_action_frankaemika_panda"
-        type="integrationtest_sequence_action" time-limit="300.0">
-    <param name="joint_prefix" value="panda_joint" />
+  <test pkg="pilz_industrial_motion_planner" test-name="integrationtest_sequence_action" type="integrationtest_sequence_action" time-limit="300.0">
     <param name="joint_position_tolerance" value="0.01" />
-    <param name="group_name" value="panda_arm" />
-    <param name="testdata_file_name"
-           value="$(find pilz_industrial_motion_planner)/test/test_robots/frankaemika_panda/test_data/testdata_sequence.xml" />
+    <param name="testdata_file_name" value="$(find pilz_industrial_motion_planner)/test/test_robots/prbt/test_data/testdata_sequence.xml" />
   </test>
 
 </launch>

--- a/moveit_planners/pilz_industrial_motion_planner/test/integrationtest_sequence_action_capability_frankaemika_panda.test
+++ b/moveit_planners/pilz_industrial_motion_planner/test/integrationtest_sequence_action_capability_frankaemika_panda.test
@@ -48,6 +48,7 @@ POSSIBILITY OF SUCH DAMAGE.
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
+    <arg name="execution_type" value="last point" />
   </include>
 
   <!-- run test -->

--- a/moveit_planners/pilz_industrial_motion_planner/test/integrationtest_sequence_action_capability_with_gripper.test
+++ b/moveit_planners/pilz_industrial_motion_planner/test/integrationtest_sequence_action_capability_with_gripper.test
@@ -50,8 +50,8 @@ POSSIBILITY OF SUCH DAMAGE.
   </include>
 
   <!-- run test -->
-  <test pkg="pilz_industrial_motion_planner" test-name="integrationtest_sequence_action_capability_with_gripper"
-        type="integrationtest_sequence_action_capability" time-limit="300.0">
+  <test pkg="pilz_industrial_motion_planner" test-name="integrationtest_sequence_action_with_gripper"
+        type="integrationtest_sequence_action" time-limit="300.0">
     <param name="joint_position_tolerance" value="0.01" />
     <param name="testdata_file_name" value="$(find pilz_industrial_motion_planner)/test/test_robots/prbt/test_data/testdata_sequence.xml" />
   </test>

--- a/moveit_planners/pilz_industrial_motion_planner/test/integrationtest_sequence_action_preemption.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/integrationtest_sequence_action_preemption.cpp
@@ -1,0 +1,180 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018 Pilz GmbH & Co. KG
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Pilz GmbH & Co. KG nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <iostream>
+#include <memory>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <chrono>
+#include <stdexcept>
+
+#include <ros/ros.h>
+#include <moveit_msgs/Constraints.h>
+#include <moveit_msgs/JointConstraint.h>
+#include <moveit_msgs/GetMotionPlan.h>
+#include <moveit/robot_state/conversions.h>
+#include <moveit/robot_model_loader/robot_model_loader.h>
+#include <moveit/robot_model/robot_model.h>
+#include <actionlib/client/simple_action_client.h>
+#include <moveit/move_group_interface/move_group_interface.h>
+#include <sensor_msgs/JointState.h>
+
+#include <pilz_testutils/async_test.h>
+
+#include <pilz_industrial_motion_planner_testutils/xml_testdata_loader.h>
+#include <pilz_industrial_motion_planner_testutils/sequence.h>
+#include <pilz_industrial_motion_planner_testutils/checks.h>
+
+#include "moveit_msgs/MoveGroupSequenceAction.h"
+
+static constexpr double WAIT_FOR_RESULT_TIME_OUT{ 5. };          // seconds
+static constexpr double TIME_BEFORE_CANCEL_GOAL{ 1.0 };      // seconds
+static constexpr double WAIT_FOR_ACTION_SERVER_TIME_OUT{ 10. };  // seconds
+
+const std::string SEQUENCE_ACTION_NAME("/sequence_move_group");
+
+// Parameters from parameter server
+const std::string JOINT_POSITION_TOLERANCE("joint_position_tolerance");
+
+// events for callback tests
+const std::string GOAL_SUCCEEDED_EVENT = "GOAL_SUCCEEDED";
+const std::string SERVER_IDLE_EVENT = "SERVER_IDLE";
+
+const std::string TEST_DATA_FILE_NAME("testdata_file_name");
+const std::string GROUP_NAME("group_name");
+
+using namespace pilz_industrial_motion_planner_testutils;
+
+class IntegrationTestSequenceAction : public testing::Test, public testing::AsyncTest
+{
+protected:
+  void SetUp() override;
+
+public:
+  MOCK_METHOD0(active_callback, void());
+  MOCK_METHOD1(feedback_callback, void(const moveit_msgs::MoveGroupSequenceFeedbackConstPtr& feedback));
+  MOCK_METHOD2(done_callback, void(const actionlib::SimpleClientGoalState& state,
+                                   const moveit_msgs::MoveGroupSequenceResultConstPtr& result));
+
+protected:
+  ros::NodeHandle ph_{ "~" };
+  actionlib::SimpleActionClient<moveit_msgs::MoveGroupSequenceAction> ac_{ ph_, SEQUENCE_ACTION_NAME, true };
+  std::shared_ptr<moveit::planning_interface::MoveGroupInterface> move_group_;
+
+  robot_model_loader::RobotModelLoader model_loader_;
+  robot_model::RobotModelPtr robot_model_;
+  double joint_position_tolerance_;
+
+  std::string test_data_file_name_;
+  std::string group_name_;
+  TestdataLoaderUPtr data_loader_;
+
+  //! The configuration at which the robot stays at the beginning of each test.
+  JointConfiguration start_config;
+};
+
+void IntegrationTestSequenceAction::SetUp()
+{
+  // get necessary parameters
+  ASSERT_TRUE(ph_.getParam(JOINT_POSITION_TOLERANCE, joint_position_tolerance_));
+  ASSERT_TRUE(ph_.getParam(TEST_DATA_FILE_NAME, test_data_file_name_));
+  ph_.param<std::string>(GROUP_NAME, group_name_, "manipulator");
+
+  robot_model_ = model_loader_.getModel();
+
+  data_loader_.reset(new XmlTestdataLoader(test_data_file_name_, robot_model_));
+  ASSERT_NE(nullptr, data_loader_) << "Failed to load test data by provider.";
+
+  // wait for action server
+  ASSERT_TRUE(ac_.waitForServer(ros::Duration(WAIT_FOR_ACTION_SERVER_TIME_OUT))) << "Action server is not active.";
+
+  // move to default position
+  start_config = data_loader_->getJoints("ZeroPose", group_name_);
+  robot_state::RobotState robot_state{ start_config.toRobotState() };
+
+  move_group_ = std::make_shared<moveit::planning_interface::MoveGroupInterface>(start_config.getGroupName());
+  move_group_->setPlannerId("PTP");
+  move_group_->setGoalTolerance(joint_position_tolerance_);
+  move_group_->setJointValueTarget(robot_state);
+  move_group_->setMaxVelocityScalingFactor(1.0);
+  move_group_->setMaxAccelerationScalingFactor(1.0);
+  move_group_->move();
+
+  ASSERT_TRUE(isAtExpectedPosition(robot_state, *(move_group_->getCurrentState()), joint_position_tolerance_));
+}
+
+/**
+ * @brief Tests that goal can be cancelled.
+ *
+ * Test Sequence:
+ *    1. Send goal for planning and execution.
+ *    2. Cancel goal before it finishes.
+ *
+ * Expected Results:
+ *    1. Goal is sent to the action server.
+ *    2. Goal is cancelled. Execution stops.
+ */
+TEST_F(IntegrationTestSequenceAction, TestCancellingOfGoal)
+{
+  Sequence seq{ data_loader_->getSequence("ComplexSequence") };
+
+  moveit_msgs::MoveGroupSequenceGoal seq_goal;
+  seq_goal.request = seq.toRequest();
+
+  ac_.sendGoal(seq_goal);
+  // wait for 1 second
+  ros::Duration(TIME_BEFORE_CANCEL_GOAL).sleep();
+
+  ac_.cancelGoal();
+  ac_.waitForResult(ros::Duration(WAIT_FOR_RESULT_TIME_OUT));
+
+  moveit_msgs::MoveGroupSequenceResultConstPtr res = ac_.getResult();
+  EXPECT_EQ(res->response.error_code.val, moveit_msgs::MoveItErrorCodes::PREEMPTED)
+      << "Error code should be preempted.";
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "integrationtest_sequence_action_preemption");
+  ros::NodeHandle nh;
+
+  ros::AsyncSpinner spinner{ 1 };
+  spinner.start();
+
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/moveit_planners/pilz_industrial_motion_planner/test/integrationtest_sequence_action_preemption.test
+++ b/moveit_planners/pilz_industrial_motion_planner/test/integrationtest_sequence_action_preemption.test
@@ -47,10 +47,11 @@ POSSIBILITY OF SUCH DAMAGE.
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
     <arg name="pipeline" value="pilz_industrial_motion_planner" />
+    <arg name="execution_type" value="interpolate" /><!-- we need to actually execute the trajectory to test preemption -->
   </include>
 
   <!-- run test -->
-  <test pkg="pilz_industrial_motion_planner" test-name="integrationtest_sequence_action_capability" type="integrationtest_sequence_action_capability" time-limit="300.0">
+  <test pkg="pilz_industrial_motion_planner" test-name="integrationtest_sequence_action_preemption" type="integrationtest_sequence_action_preemption" time-limit="20.0">
     <param name="joint_position_tolerance" value="0.01" />
     <param name="testdata_file_name" value="$(find pilz_industrial_motion_planner)/test/test_robots/prbt/test_data/testdata_sequence.xml" />
   </test>

--- a/moveit_planners/pilz_industrial_motion_planner/test/test_robots/frankaemika_panda/config/joint_limits.yaml
+++ b/moveit_planners/pilz_industrial_motion_planner/test/test_robots/frankaemika_panda/config/joint_limits.yaml
@@ -43,16 +43,16 @@ joint_limits:
     max_acceleration: 1.0
   panda_joint4:
     has_acceleration_limits: true
-    max_acceleration: 1.0  
+    max_acceleration: 1.0
   panda_joint5:
     has_acceleration_limits: true
-    max_acceleration: 1.0  
+    max_acceleration: 1.0
   panda_joint6:
     has_acceleration_limits: true
-    max_acceleration: 1.0  
+    max_acceleration: 1.0
   panda_joint7:
     has_acceleration_limits: true
-    max_acceleration: 1.0  
+    max_acceleration: 1.0
 
   panda_hand_joint:
     has_acceleration_limits: true

--- a/moveit_planners/pilz_industrial_motion_planner/test/test_robots/frankaemika_panda/launch/move_group.launch
+++ b/moveit_planners/pilz_industrial_motion_planner/test/test_robots/frankaemika_panda/launch/move_group.launch
@@ -28,6 +28,7 @@
   <!-- move_group settings -->
   <arg name="allow_trajectory_execution" default="true"/>
   <arg name="fake_execution" default="false"/>
+  <arg name="execution_type" default="interpolate"/> <!-- set to 'last point' to skip intermediate trajectory in fake execution -->
   <arg name="max_safe_path_cost" default="1"/>
   <arg name="jiggle_fraction" default="0.05" />
   <arg name="publish_monitored_planning_scene" default="true"/>
@@ -41,6 +42,7 @@
     <arg name="moveit_controller_manager" value="panda" if="$(eval not arg('fake_execution') and not arg('load_gripper'))"/>
     <arg name="moveit_controller_manager" value="panda_gripper" if="$(eval not arg('fake_execution') and arg('load_gripper'))"/>
     <arg name="moveit_controller_manager" value="fake" if="$(arg fake_execution)"/>
+    <arg name="execution_type" value="$(arg execution_type)" />
   </include>
 
   <!-- Start the actual move_group node/action server -->

--- a/moveit_planners/pilz_industrial_motion_planner/test/test_robots/prbt/launch/test_context.launch
+++ b/moveit_planners/pilz_industrial_motion_planner/test/test_robots/prbt/launch/test_context.launch
@@ -10,7 +10,7 @@
 
   <!-- Load universal robot description format (URDF) -->
   <param name="$(arg robot_description)"
-         command="$(find xacro)/xacro --inorder $(find prbt_support)/urdf/prbt.xacro gripper:=$(arg gripper)"/>
+         command="$(find xacro)/xacro --inorder $(find moveit_resources_prbt_support)/urdf/prbt.xacro gripper:=$(arg gripper)"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" command="$(find xacro)/xacro --inorder

--- a/moveit_planners/pilz_industrial_motion_planner_testutils/include/pilz_industrial_motion_planner_testutils/checks.h
+++ b/moveit_planners/pilz_industrial_motion_planner_testutils/include/pilz_industrial_motion_planner_testutils/checks.h
@@ -41,29 +41,22 @@
 namespace pilz_industrial_motion_planner_testutils
 {
 ::testing::AssertionResult isAtExpectedPosition(const robot_state::RobotState& expected,
-                                                const robot_state::RobotState& actual, const double epsilon)
+                                                const robot_state::RobotState& actual,
+                                                const double epsilon,
+                                                const std::string& group_name = "")
 {
-  if (expected.getVariableCount() != actual.getVariableCount())
+  if (group_name.empty() && expected.distance(actual) <= epsilon)
   {
-    return ::testing::AssertionFailure() << "Both states have different number of Variables";
+    return ::testing::AssertionSuccess();
   }
-
-  for (size_t i = 0; i < actual.getVariableCount(); ++i)
-  {
-    // PLEASE NOTE: This comparision only works for reasonably
-    // values. That means: Values are not to large, values are
-    // reasonably close by each other.
-    if (std::fabs(expected.getVariablePosition(i) - actual.getVariablePosition(i)) > epsilon)
-    {
-      std::stringstream msg;
-      msg << expected.getVariableNames().at(i) << " position - expected: " << expected.getVariablePosition(i)
-          << " actual: " << actual.getVariablePosition(i);
-
-      return ::testing::AssertionFailure() << msg.str();
-    }
+  else if (!group_name.empty() && expected.distance(actual, actual.getJointModelGroup(group_name)) <= epsilon) {
+    return ::testing::AssertionSuccess();
   }
+  std::stringstream msg;
+  msg << " expected: " << expected
+      << " actual: " << actual;
 
-  return ::testing::AssertionSuccess();
+  return ::testing::AssertionFailure() << msg.str();
 }
 }
 


### PR DESCRIPTION
This PR needs https://github.com/PilzDE/moveit_resources/pull/1 as prerequisite.

### integrationtest_sequence_action:
* set execution mode to 'last point' to directly jump to the goal of the planned trajectory
* split TestCancellingOfGoal into its own test case with real execution

This speeds up testing time of integrationtest_sequence_action test suite from 289 seconds to 43 seconds (locally).


### next steps
we also need to add such a parameter to pg70 and panda packages to speedup `integrationtest_sequence_action_capability_with_gripper.test` and `integrationtest_sequence_action_frankaemika_panda` as well...